### PR TITLE
Webview debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,24 @@ Please, see `counter-go` example for more details about how to bind Go controlle
 
 ## Debugging and development tips
 
-On Linux every `log.Println()` would appear in the terminal output. So does every `console.log()` from the JS code and every JS error, so development is a very pleasant experience.
+If terminal output is unavailable (e.g. if you launch app bundle on MacOS or
+GUI app on Windows) you may use `webview.Debug()` and `webview.Debugf()` to
+print logs. On MacOS such logs will be printed via NSLog and can be seen in the
+`Console` app. On Windows they use `OutputDebugString` and can be seen using
+`DebugView` app. On Linux logging is done to stderr and can be seen in the
+terminal or redirected to a file.
 
-On Windows you will see native logs only if you omit the `-H windowsgui` linker flag. In this case you will see a black CMD console attached to your app and output will be shown there. JS errors will be shown as popup dialogs. Unfortunately, `console.log()` output won't be shown at all.
+To debug the web part of your app you may use `webview.Settings.Debug` flag. It
+enables Web Inspector in WebKit and work on Linux and MacOS (use popup menu to
+open the web inspector). On Windows there is no easy to way to enable
+debugging, but you may include Firebug in your HTML code:
 
-On MacOS if you run an app from the terminal - you get its standard output printed. If you run it from Finder or using `open` command - you don't see any logs.
+```html
+<script type="text/javascript" src="https://getfirebug.com/firebug-lite.js"></script>
+```
+
+Even though Firebug browser extension development has been stopped, Firebug
+Lite is still available and just works.
 
 ## Distributing webview apps
 
@@ -225,6 +238,8 @@ If you want to have more control over the app lifecycle you can use the followin
       .url = url,
       .width = w,
       .height = h,
+      .resizable = 1,
+      .debug = 0,
       .resizable = resizable,
   };
   /* Create webview window using the provided options */
@@ -239,6 +254,9 @@ If you want to have more control over the app lifecycle you can use the followin
 
   /* To terminate the webview main loop: */
   webview_terminate(&webview);
+
+  /* To print logs to stderr, MacOS Console or DebugView: */
+  webview_debug("exited: %d\n", 1);
 ```
 
 To evaluate arbitrary javascript code use the following C function:

--- a/webview.go
+++ b/webview.go
@@ -128,6 +128,22 @@ func Open(title, url string, w, h int, resizable bool) error {
 	return nil
 }
 
+// Output a debug string. Uses stderr on Linux/BSD, NSLog on MacOS and
+// OutputDebugString on Windows.
+func Debug(a ...interface{}) {
+	s := C.CString(fmt.Sprint(a...))
+	defer C.free(unsafe.Pointer(s))
+	C.webview_print_log(s)
+}
+
+// Output formatted debug string. Uses stderr on Linux/BSD, NSLog on MacOS and
+// OutputDebugString on Windows.
+func Debugf(format string, a ...interface{}) {
+	s := C.CString(fmt.Sprintf(format, a...))
+	defer C.free(unsafe.Pointer(s))
+	C.webview_print_log(s)
+}
+
 // ExternalInvokeCallbackFunc is a function type that is called every time
 // "window.external.invoke_()" is called from JavaScript. Data is the only
 // obligatory string parameter passed into the "invoke_(data)" function from

--- a/webview.h
+++ b/webview.h
@@ -258,7 +258,7 @@ static int webview_init(struct webview *w) {
                      G_CALLBACK(webview_inspector_create_cb), w);
     g_signal_connect(G_OBJECT(inspector), "show-window",
                      G_CALLBACK(webview_inspector_show_cb), w);
-    g_signal_connect(G_OBJECT(inspector), "hide-window",
+    g_signal_connect(G_OBJECT(inspector), "close-window",
                      G_CALLBACK(webview_inspector_hide_cb), w);
   } else {
     g_signal_connect(G_OBJECT(w->priv.webview), "context-menu",

--- a/webview.h
+++ b/webview.h
@@ -1467,6 +1467,8 @@ static int webview_init(struct webview *w) {
   [w->priv.window setDelegate:w->priv.windowDelegate];
   [w->priv.window center];
 
+  [[NSUserDefaults standardUserDefaults] setBool:!!w->debug forKey:@"WebKitDeveloperExtras"];
+  [[NSUserDefaults standardUserDefaults] synchronize];
   w->priv.webview =
       [[WebView alloc] initWithFrame:r frameName:@"WebView" groupName:nil];
   NSURL *nsURL = [NSURL URLWithString:[NSString stringWithUTF8String:w->url]];

--- a/webview.h
+++ b/webview.h
@@ -14,6 +14,7 @@ struct webview_priv {
   GtkWidget *window;
   GtkWidget *scroller;
   GtkWidget *webview;
+  GtkWidget *inspector_window;
   int should_exit;
 };
 #elif defined(WEBVIEW_WINAPI)
@@ -59,6 +60,7 @@ struct webview {
   int width;
   int height;
   int resizable;
+  int debug;
   webview_external_invoke_cb_t external_invoke_cb;
   struct webview_priv priv;
   void *userdata;
@@ -182,6 +184,35 @@ static void webview_window_object_cleared_cb(WebKitWebView *webview,
   JSObjectSetProperty(context, glob, s, obj, kJSPropertyAttributeNone, NULL);
 }
 
+static WebKitWebView *webview_inspector_create_cb(WebKitWebInspector *inspector,
+                                                  WebKitWebView *view,
+                                                  gpointer arg) {
+  struct webview *w = (struct webview *)arg;
+  w->priv.inspector_window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+  gtk_window_set_title(GTK_WINDOW(w->priv.inspector_window), "WebInspector");
+  gtk_window_set_default_size(GTK_WINDOW(w->priv.inspector_window), 640, 480);
+  GtkWidget *scroll = gtk_scrolled_window_new(NULL, NULL);
+  gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scroll),
+                                 GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
+  gtk_container_add(GTK_CONTAINER(w->priv.inspector_window), scroll);
+  gtk_widget_show(scroll);
+  GtkWidget *webview = webkit_web_view_new();
+  gtk_container_add(GTK_CONTAINER(scroll), webview);
+  return WEBKIT_WEB_VIEW(webview);
+}
+
+static gboolean webview_inspector_show_cb(WebKitWebInspector *inspector,
+                                          gpointer arg) {
+  gtk_widget_show(((struct webview *)arg)->priv.inspector_window);
+  return TRUE;
+}
+
+static gboolean webview_inspector_hide_cb(WebKitWebInspector *inspector,
+                                          gpointer arg) {
+  gtk_widget_hide(((struct webview *)arg)->priv.inspector_window);
+  return TRUE;
+}
+
 static int webview_init(struct webview *w) {
   if (gtk_init_check(0, NULL) == FALSE) {
     return -1;
@@ -207,12 +238,27 @@ static int webview_init(struct webview *w) {
   webkit_web_view_load_uri(WEBKIT_WEB_VIEW(w->priv.webview), w->url);
   gtk_container_add(GTK_CONTAINER(w->priv.scroller), w->priv.webview);
 
+  if (w->debug) {
+    WebKitWebSettings *settings =
+        webkit_web_view_get_settings(WEBKIT_WEB_VIEW(w->priv.webview));
+    g_object_set(G_OBJECT(settings), "enable-developer-extras", TRUE, NULL);
+    WebKitWebInspector *inspector =
+        webkit_web_view_get_inspector(WEBKIT_WEB_VIEW(w->priv.webview));
+    g_signal_connect(G_OBJECT(inspector), "inspect-web-view",
+                     G_CALLBACK(webview_inspector_create_cb), w);
+    g_signal_connect(G_OBJECT(inspector), "show-window",
+                     G_CALLBACK(webview_inspector_show_cb), w);
+    g_signal_connect(G_OBJECT(inspector), "hide-window",
+                     G_CALLBACK(webview_inspector_hide_cb), w);
+  } else {
+    g_signal_connect(G_OBJECT(w->priv.webview), "context-menu",
+                     G_CALLBACK(webview_context_menu_cb), w);
+  }
+
   gtk_widget_show_all(w->priv.window);
 
   g_signal_connect(G_OBJECT(w->priv.window), "destroy",
                    G_CALLBACK(webview_desroy_cb), w);
-  g_signal_connect(G_OBJECT(w->priv.webview), "context-menu",
-                   G_CALLBACK(webview_context_menu_cb), w);
   g_signal_connect(G_OBJECT(w->priv.webview), "window-object-cleared",
                    G_CALLBACK(webview_window_object_cleared_cb), w);
   return 0;


### PR DESCRIPTION
* Adds `webview_debug()` to print logs to stderr on Linux, Console app on MacOS and DebugView on Windows. It enables logging when there is no terminal available.
* Adds `webview.Debug()` and `webview.Debugf()` in Go
* Adds `debug` and `webview.Settings.Debug` field to enable WebInspector on Linux and MacOS.

All the above, plus FirebugLite on Windows make it a pleasant environment for building web UI.