### PR TITLE
add methods to allow customization of window icon

### DIFF
--- a/examples/minimal-go/main.go
+++ b/examples/minimal-go/main.go
@@ -5,5 +5,5 @@ import "github.com/zserge/webview"
 func main() {
 	// Open wikipedia in a 800x600 resizable window
 	webview.Open("Minimal webview example",
-		"https://en.m.wikipedia.org/wiki/Main_Page", 800, 600, true)
+		"https://en.m.wikipedia.org/wiki/Main_Page", 800, 600, true, "")
 }

--- a/examples/minimal/main.c
+++ b/examples/minimal/main.c
@@ -9,6 +9,6 @@ int main() {
 #endif
   /* Open wikipedia in a 800x600 resizable window */
   webview("Minimal webview example",
-	  "https://en.m.wikipedia.org/wiki/Main_Page", 800, 600, 1);
+	  "https://en.m.wikipedia.org/wiki/Main_Page", 800, 600, 1, "");
   return 0;
 }

--- a/webview.go
+++ b/webview.go
@@ -72,6 +72,10 @@ static inline void CgoWebViewSetColor(void *w, uint8_t r, uint8_t g, uint8_t b, 
 	webview_set_color((struct webview *)w, r, g, b, a);
 }
 
+static inline void CgoWebViewSetIcon(void *w, char *icon) {
+	webview_set_icon((struct webview *)w, icon);
+}
+
 static inline void CgoDialog(void *w, int dlgtype, int flags,
 		char *title, char *arg, char *res, size_t ressz) {
 	webview_dialog(w, dlgtype, flags,
@@ -198,6 +202,9 @@ type WebView interface {
 	// SetColor() changes window background color. This method must be called from
 	// the main thread only. See Dispatch() for more details.
 	SetColor(r, g, b, a uint8)
+	// SetIcon() changes the window icon. This method must be called from the
+	// main thread only. See Dispatch() for more details.
+	SetIcon(icon string)
 	// Eval() evaluates an arbitrary JS code inside the webview. This method must
 	// be called from the main thread only. See Dispatch() for more details.
 	Eval(js string)
@@ -334,6 +341,12 @@ func (w *webview) SetTitle(title string) {
 
 func (w *webview) SetColor(r, g, b, a uint8) {
 	C.CgoWebViewSetColor(w.w, C.uint8_t(r), C.uint8_t(g), C.uint8_t(b), C.uint8_t(a))
+}
+
+func (w *webview) SetIcon(file string) {
+	p := C.CString(file)
+	defer C.free(unsafe.Pointer(p))
+	C.CgoWebViewSetIcon(w.w, p)
 }
 
 func (w *webview) SetFullscreen(fullscreen bool) {

--- a/webview.h
+++ b/webview.h
@@ -358,11 +358,11 @@ WEBVIEW_API void webview_set_title(struct webview *w, const char *title) {
 }
 
 WEBVIEW_API int webview_set_icon(struct webview *w, const char *icon) {
-  if (w->icon == NULL || w->icon == "") {
+  if (icon == NULL || icon == "") {
     return 0;
   }
 
-  GError *gerror;
+  GError *gerror = NULL;
   GdkPixbuf *image = gdk_pixbuf_new_from_file(icon, &gerror);
 
   if (gerror != NULL) {
@@ -1769,7 +1769,7 @@ WEBVIEW_API void webview_set_title(struct webview *w, const char *title) {
 }
 
 WEBVIEW_API int webview_set_icon(struct webview *w, const char *icon) {
-
+  return 0;
 }
 
 WEBVIEW_API void webview_set_fullscreen(struct webview *w, int fullscreen) {

--- a/webview.h
+++ b/webview.h
@@ -1607,6 +1607,8 @@ WEBVIEW_API void webview_print_log(const char *s) { OutputDebugString(s); }
 #define NSEventModifierFlagCommand NSCommandKeyMask
 #define NSEventModifierFlagOption NSAlternateKeyMask
 #define NSAlertStyleInformational NSInformationalAlertStyle
+#define NSAlertStyleCritical NSCriticalAlertStyle
+#define NSAlertStyleWarning NSWarningAlertStyle
 #endif /* MAC_OS_X_VERSION_10_12 */
 #if (!defined MAC_OS_X_VERSION_10_13) ||                                       \
     MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_13

--- a/webview.h
+++ b/webview.h
@@ -1240,6 +1240,8 @@ WEBVIEW_API int webview_init(struct webview *w) {
 
   SetWindowLongPtr(w->priv.hwnd, GWLP_USERDATA, (LONG_PTR)w);
 
+  webview_set_icon(w, w->icon);
+
   DisplayHTMLPage(w);
 
   SetWindowText(w->priv.hwnd, w->title);

--- a/webview.h
+++ b/webview.h
@@ -156,6 +156,7 @@ WEBVIEW_API int webview_loop(struct webview *w, int blocking);
 WEBVIEW_API int webview_eval(struct webview *w, const char *js);
 WEBVIEW_API int webview_inject_css(struct webview *w, const char *css);
 WEBVIEW_API void webview_set_title(struct webview *w, const char *title);
+WEBVIEW_API void webview_set_icon(struct webview *w, const char *icon);
 WEBVIEW_API void webview_set_fullscreen(struct webview *w, int fullscreen);
 WEBVIEW_API void webview_set_color(struct webview *w, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 WEBVIEW_API void webview_dialog(struct webview *w,
@@ -349,6 +350,11 @@ WEBVIEW_API int webview_loop(struct webview *w, int blocking) {
 
 WEBVIEW_API void webview_set_title(struct webview *w, const char *title) {
   gtk_window_set_title(GTK_WINDOW(w->priv.window), title);
+}
+
+
+WEBVIEW_API void webview_set_icon(struct webview *w, const char *icon) {
+
 }
 
 WEBVIEW_API void webview_set_fullscreen(struct webview *w, int fullscreen) {
@@ -1339,6 +1345,13 @@ WEBVIEW_API void webview_set_title(struct webview *w, const char *title) {
   SetWindowText(w->priv.hwnd, title);
 }
 
+WEBVIEW_API void webview_set_icon(struct webview *w, const char *icon) {
+    HINSTANCE hInstance = GetModuleHandle(NULL);
+
+    HANDLE wIcon = LoadImage(hInstance, icon, IMAGE_ICON, 32, 32, LR_LOADFROMFILE);
+    SendMessage(w->priv.hwnd, (UINT)WM_SETICON, ICON_BIG, (LPARAM)wIcon);
+}
+
 WEBVIEW_API void webview_set_fullscreen(struct webview *w, int fullscreen) {
   if (w->priv.is_fullscreen == !!fullscreen) {
     return;
@@ -1732,6 +1745,10 @@ WEBVIEW_API int webview_eval(struct webview *w, const char *js) {
 WEBVIEW_API void webview_set_title(struct webview *w, const char *title) {
   NSString *nsTitle = [NSString stringWithUTF8String:title];
   [w->priv.window setTitle:nsTitle];
+}
+
+WEBVIEW_API void webview_set_icon(struct webview *w, const char *icon) {
+
 }
 
 WEBVIEW_API void webview_set_fullscreen(struct webview *w, int fullscreen) {

--- a/webview.h
+++ b/webview.h
@@ -1766,7 +1766,7 @@ WEBVIEW_API void webview_set_title(struct webview *w, const char *title) {
   [w->priv.window setTitle:nsTitle];
 }
 
-WEBVIEW_API void webview_set_icon(struct webview *w, const char *icon) {
+WEBVIEW_API int webview_set_icon(struct webview *w, const char *icon) {
 
 }
 


### PR DESCRIPTION
Hi! Following #28, I've implemented the ability to set a window icon on Windows and Linux. This PR doesn't match the full details of the issue yet, but I wanted to open this now to allow for discussion around it.

My current implementation sets the icon from a file on disk, which I know is not ideal nor what was specified in the original issue. This is because I didn't know how to achieve this on Windows (despite digging through a lot of documentation), nor how to pass binary icon data via Cgo (though I didn't really get far enough into that to do too much digging...).

One idea I did have was to use go-bindata or similar to embed an icon file and then on initialisation place that file somewhere on the disk (other libraries I have seen do this), however that is a go-specific solution, and I'm conscious this library also supports C/C++/etc. 

Let me know what you think, and thanks for the awesome library :).