### PR TITLE
cocoa: rollback eval to not returning -1

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -1725,10 +1725,7 @@ WEBVIEW_API int webview_loop(struct webview *w, int blocking) {
 
 WEBVIEW_API int webview_eval(struct webview *w, const char *js) {
   NSString *nsJS = [NSString stringWithUTF8String:js];
-  id u = [[w->priv.webview windowScriptObject] evaluateWebScript:nsJS];
-  if ([u isKindOfClass:[WebUndefined class]] == YES) {
-    return -1;
-  }
+  [[w->priv.webview windowScriptObject] evaluateWebScript:nsJS];
   return 0;
 }
 


### PR DESCRIPTION
I apologize. Actually it has not worked at all that ensuring the return value of `evaluateWebScript` is the class `WebUndefined`. That have been always `YES`. I guess that we can not determine whether if an exception is thrown or not explicitly in WebScriptObject.