### PR TITLE
Added SetTitleBarColor() for mac only

### DIFF
--- a/webview.go
+++ b/webview.go
@@ -93,6 +93,11 @@ static inline void _webview_dispatch_cb(struct webview *w, void *arg) {
 static inline void CgoWebViewDispatch(void *w, uintptr_t arg) {
 	webview_dispatch((struct webview *)w, _webview_dispatch_cb, (void *)arg);
 }
+
+static inline void CgoWebViewSetTitlebarColor(void *w, float r, float g, float b, float a) {
+	webview_set_titlebar_color((struct webview *)w, r, g, b, a);
+}
+
 */
 import "C"
 import (
@@ -198,6 +203,9 @@ type WebView interface {
 	// SetColor() changes window background color. This method must be called from
 	// the main thread only. See Dispatch() for more details.
 	SetColor(r, g, b, a uint8)
+	//SetTitlebarColor() changes titlebar color. Mac only. This method must be called
+	//from the main thread only. See Dispatch() for more details.
+	SetTitlebarColor(r, g, b, a float64)
 	// Eval() evaluates an arbitrary JS code inside the webview. This method must
 	// be called from the main thread only. See Dispatch() for more details.
 	Eval(js string) error
@@ -330,6 +338,10 @@ func (w *webview) SetTitle(title string) {
 	p := C.CString(title)
 	defer C.free(unsafe.Pointer(p))
 	C.CgoWebViewSetTitle(w.w, p)
+}
+
+func (w *webview) SetTitlebarColor(r, g, b, a float64) {
+	C.CgoWebViewSetTitlebarColor(w.w, C.float(r), C.float(g), C.float(b), C.float(a))
 }
 
 func (w *webview) SetColor(r, g, b, a uint8) {

--- a/webview.h
+++ b/webview.h
@@ -168,6 +168,7 @@ WEBVIEW_API void webview_terminate(struct webview *w);
 WEBVIEW_API void webview_exit(struct webview *w);
 WEBVIEW_API void webview_debug(const char *format, ...);
 WEBVIEW_API void webview_print_log(const char *s);
+WEBVIEW_API void webview_set_titlebar_color(struct webview *w, float r, float g, float b, float a);
 
 #ifdef WEBVIEW_IMPLEMENTATION
 #undef WEBVIEW_IMPLEMENTATION
@@ -1667,6 +1668,7 @@ WEBVIEW_API int webview_init(struct webview *w) {
   w->priv.webview.frameLoadDelegate = w->priv.windowDelegate;
   [[w->priv.window contentView] addSubview:w->priv.webview];
   [w->priv.window orderFrontRegardless];
+  [w->priv.window setTitlebarAppearsTransparent:YES];
 
   [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
   [NSApp finishLaunching];
@@ -1709,6 +1711,14 @@ WEBVIEW_API int webview_init(struct webview *w) {
 
   w->priv.should_exit = 0;
   return 0;
+}
+
+WEBVIEW_API void webview_set_titlebar_color(struct webview *w, float r,
+                                          float g, float b, float a) {
+
+  NSColor *rgb = [NSColor colorWithDeviceRed:r green:g blue:b alpha: a];
+  [w->priv.window setBackgroundColor:rgb];
+
 }
 
 WEBVIEW_API int webview_loop(struct webview *w, int blocking) {
@@ -1755,9 +1765,7 @@ WEBVIEW_API void webview_set_color(struct webview *w, uint8_t r, uint8_t g, uint
   } else {
     [w->priv.window setAppearance:[NSAppearance appearanceNamed:NSAppearanceNameVibrantLight]];
   }
-  [w->priv.window setOpaque:NO];
-  [w->priv.window setTitlebarAppearsTransparent:YES];
-  [w->priv.webview setDrawsBackground:NO];
+  [w->priv.window setOpaque:YES];
 }
 
 WEBVIEW_API void webview_dialog(struct webview *w,


### PR DESCRIPTION
I couldn't create a transparent titlebar because then the window would become undraggable. So I created this function to set the titlebar color so my app background and titlebar background match and looks like it is transparent.