### PR TITLE
Minor README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/zserge/webview)](https://goreportcard.com/report/github.com/zserge/webview)
 
 
-A tiny cross-platform webview library for C/C++/Golang to build modern cross-platform GUI. Also, there are [Rust bindings](https://github.com/Boscop/webview-rs) and [Nim bindings](https://github.com/oskca/webview) available.
+A tiny cross-platform webview library for C/C++/Golang to build modern cross-platform GUIs. Also, there are [Rust bindings](https://github.com/Boscop/webview-rs) and [Nim bindings](https://github.com/oskca/webview) available.
 
 It supports two-way JavaScript bindings (to call JavaScript from C/C++/Go and to call C/C++/Go from JavaScript).
 
@@ -16,7 +16,7 @@ It uses Cocoa/WebKit on macOS, gtk-webkit2 on Linux and MSHTML (IE10/11) on Wind
 
 ## Webview for Go developers
 
-If you are interested in writing Webview apps in C/C++ - skip to the next section.
+If you are interested in writing Webview apps in C/C++, [skip to the next section](#webview-for-cc-developers).
 
 ### Getting started
 
@@ -68,7 +68,7 @@ First of all, you probably want to embed your assets (HTML/CSS/JavaScript) into 
 Now there are two major approaches to deploy the content:
 
 * Serve HTML/CSS/JS with an embedded HTTP server
-* Injecting HTML/CSS/JS via JavaScript binding API
+* Injecting HTML/CSS/JS via the JavaScript binding API
 
 To serve the content it is recommended to use ephemeral ports:
 
@@ -87,7 +87,7 @@ webview.Open("Hello", "http://"+ln.Addr().String(), 400, 300, false)
 
 Injecting the content via JS bindings is a bit more complicated, but feels more solid and does not expose any additional open TCP ports.
 
-Leave `webview.Settings.URL` empty to start with a bare minimal HTML5. It will open a webview with `<div id="app"></div>` in it. Alternatively, use data URI to inject custom HTML code (don't forget to URL-encode it):
+Leave `webview.Settings.URL` empty to start with bare minimal HTML5. It will open a webview with `<div id="app"></div>` in it. Alternatively, use a data URI to inject custom HTML code (don't forget to URL-encode it):
 
 ```go
 const myHTML = `<!doctype html><html>....</html>`
@@ -142,8 +142,8 @@ print logs. On MacOS such logs will be printed via NSLog and can be seen in the
 terminal or redirected to a file.
 
 To debug the web part of your app you may use `webview.Settings.Debug` flag. It
-enables Web Inspector in WebKit and work on Linux and MacOS (use popup menu to
-open the web inspector). On Windows there is no easy to way to enable
+enables the Web Inspector in WebKit and works on Linux and MacOS (use popup menu
+to open the web inspector). On Windows there is no easy to way to enable
 debugging, but you may include Firebug in your HTML code:
 
 ```html
@@ -155,7 +155,7 @@ Lite is still available and just works.
 
 ## Distributing webview apps
 
-On Linux you get a standalone executable. It will depend on GTK3 and GtkWebkit2, so if you distribute your app in DEB or RPM format include those dependencies. Application icon can be specified by providing a `.desktop` file.
+On Linux you get a standalone executable. It will depend on GTK3 and GtkWebkit2, so if you distribute your app in DEB or RPM format include those dependencies. An application icon can be specified by providing a `.desktop` file.
 
 On MacOS you are likely to ship an app bundle. Make the following directory structure and just zip it:
 
@@ -169,7 +169,7 @@ example.app
         └── example.icns
 ```
 
-Here, `Info.plist` is a [property list file](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/AboutInformationPropertyListFiles.html) and `*.icns` is a special icon format. You may convert PNG to icns [online](iconverticons.com/online/).
+Here, `Info.plist` is a [property list file](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/AboutInformationPropertyListFiles.html) and `*.icns` is a special icon format. You may convert PNG to icns [online](https://iconverticons.com/online/).
 
 On Windows you probably would like to have a custom icon for your executable. It can be done by providing a resource file, compiling it and linking with it. Typically, `windres` utility is used to compile resources.
 
@@ -205,7 +205,7 @@ Build it:
 
 ```bash
 # Linux
-$ cc main.c -DWEBVIEW_GTK=1 $(shell pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.0) -o webview-example
+$ cc main.c -DWEBVIEW_GTK=1 `pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.0` -o webview-example
 # MacOS
 $ cc main.c -DWEBVIEW_COCOA=1 -x objective-c -framework Cocoa -framework WebKit -o webview-example
 # Windows (mingw)
@@ -239,8 +239,7 @@ If you want to have more control over the app lifecycle you can use the followin
       .url = url,
       .width = w,
       .height = h,
-      .resizable = 1,
-      .debug = 0,
+      .debug = debug,
       .resizable = resizable,
   };
   /* Create webview window using the provided options */
@@ -299,7 +298,7 @@ webview_dispatch(w, render, some_arg);
 
 You may find some C/C++ examples in this repo that demonstrate the API above.
 
-Also, there is a more more advanced complete C++ app, [Slide](https://github.com/zserge/slide), that uses webview as a GUI. You may have a look how webview apps can be built, packages and how automatic CI/CD can be set up.
+Also, there is a more more advanced complete C++ app, [Slide](https://github.com/zserge/slide), that uses webview as a GUI. You may have a look how webview apps can be built, packaged and how automatic CI/CD can be set up.
 
 ## Notes
 


### PR DESCRIPTION
* Make "skip to C/C++ section" a link
* Fix broken link to iconverticons.com
* Use \`backticks\` to be consistent with the sh-style `$` prompt in the Linux build instructions (`$(shell ...)` is Makefile syntax)
* Remove typo in designated initializer (.resizable repeated)
* Some minor grammar fixes