### PR TITLE
Fix showing window on Windows under debugger

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -1163,7 +1163,6 @@ static int webview_fix_ie_compat_mode() {
 WEBVIEW_API int webview_init(struct webview *w) {
   WNDCLASSEX wc;
   HINSTANCE hInstance;
-  STARTUPINFO info;
   DWORD style;
   RECT clientRect;
   RECT rect;
@@ -1176,7 +1175,6 @@ WEBVIEW_API int webview_init(struct webview *w) {
   if (hInstance == NULL) {
     return -1;
   }
-  GetStartupInfo(&info);
   if (OleInitialize(NULL) != S_OK) {
     return -1;
   }
@@ -1220,7 +1218,7 @@ WEBVIEW_API int webview_init(struct webview *w) {
   DisplayHTMLPage(w);
 
   SetWindowText(w->priv.hwnd, w->title);
-  ShowWindow(w->priv.hwnd, info.wShowWindow);
+  ShowWindow(w->priv.hwnd, SW_SHOWDEFAULT);
   UpdateWindow(w->priv.hwnd);
   SetFocus(w->priv.hwnd);
 


### PR DESCRIPTION
Visual Studio doesn't set STARTF_USESHOWWINDOW flag in the STARTUPINFO when running an app and set wShowWindow to zero, so using it for ShowWindow effectively hides the window.
One can use SW_SHOWDEFAULT flag which use STARTUPINFO field if correspondning flag is set.