### PR TITLE
Add Webview `alloc` & `release` API

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -155,7 +155,8 @@ WEBVIEW_API int webview(const char *title, const char *url, int width,
 
 WEBVIEW_API struct webview* webview_alloc(const char* title, const char* url,
                                           int width, int height,
-                                          int resizeable);
+                                          int resizable, int debug,
+                                          webview_external_invoke_cb_t cb);
 WEBVIEW_API void webview_release(struct webview* webview);
 
 WEBVIEW_API int webview_init(struct webview *w);
@@ -199,15 +200,18 @@ WEBVIEW_API int webview(const char *title, const char *url, int width,
   return 0;
 }
 
-WEBVIEW_API struct webview* webview_alloc(const char *title, const char *url,
+WEBVIEW_API struct webview* webview_alloc(const char* title, const char* url,
                                           int width, int height,
-                                          int resizable) {
+                                          int resizable, int debug,
+                                          webview_external_invoke_cb_t cb) {
   struct webview* webview = (struct webview*)calloc(1, sizeof(*webview));
   webview->title = title;
   webview->url = url;
   webview->width = width;
   webview->height = height;
   webview->resizable = resizable;
+  webview->debug = debug;
+  webview->external_invoke_cb = cb;
   return webview;
 }
 

--- a/webview.h
+++ b/webview.h
@@ -212,6 +212,13 @@ WEBVIEW_API struct webview* webview_alloc(const char* title, const char* url,
   webview->resizable = resizable;
   webview->debug = debug;
   webview->external_invoke_cb = cb;
+
+  int r = webview_init(webview);
+  if (r != 0) {
+    webview_release(webview);
+    return NULL;
+  }
+  
   return webview;
 }
 

--- a/webview.h
+++ b/webview.h
@@ -178,6 +178,9 @@ WEBVIEW_API void webview_exit(struct webview *w);
 WEBVIEW_API void webview_debug(const char *format, ...);
 WEBVIEW_API void webview_print_log(const char *s);
 
+WEBVIEW_API void webview_set_userdata(struct webview* w, void* userdata);
+WEBVIEW_API void* webview_get_userdata(struct webview* w);
+
 #ifdef WEBVIEW_IMPLEMENTATION
 #undef WEBVIEW_IMPLEMENTATION
 
@@ -224,6 +227,16 @@ WEBVIEW_API struct webview* webview_alloc(const char* title, const char* url,
 
 WEBVIEW_API void webview_release(struct webview* webview) {
   free(webview);
+}
+
+WEBVIEW_API void webview_set_userdata(struct webview* w, void* ud)
+{
+  w->userdata = ud;
+}
+
+WEBVIEW_API void* webview_get_userdata(struct webview* w)
+{
+  return w->userdata;
 }
 
 WEBVIEW_API void webview_debug(const char *format, ...) {

--- a/webview.h
+++ b/webview.h
@@ -153,6 +153,11 @@ static const char *webview_check_url(const char *url) {
 WEBVIEW_API int webview(const char *title, const char *url, int width,
                         int height, int resizable);
 
+WEBVIEW_API struct webview* webview_alloc(const char* title, const char* url,
+                                          int width, int height,
+                                          int resizeable);
+WEBVIEW_API void webview_release(struct webview* webview);
+
 WEBVIEW_API int webview_init(struct webview *w);
 WEBVIEW_API int webview_loop(struct webview *w, int blocking);
 WEBVIEW_API int webview_eval(struct webview *w, const char *js);
@@ -192,6 +197,22 @@ WEBVIEW_API int webview(const char *title, const char *url, int width,
   }
   webview_exit(&webview);
   return 0;
+}
+
+WEBVIEW_API struct webview* webview_alloc(const char *title, const char *url,
+                                          int width, int height,
+                                          int resizable) {
+  struct webview* webview = (struct webview*)calloc(1, sizeof(*webview));
+  webview->title = title;
+  webview->url = url;
+  webview->width = width;
+  webview->height = height;
+  webview->resizable = resizable;
+  return webview;
+}
+
+WEBVIEW_API void webview_release(struct webview* webview) {
+  free(webview);
 }
 
 WEBVIEW_API void webview_debug(const char *format, ...) {


### PR DESCRIPTION
This allows creating the webview and treating it as an opaque
pointer. For embedding when knowing the exact layout of a struct can
be tricky.

Not sure if the alloc should call webview_init or not? I have left it so
it isn't called to allow manipulation of other things before the loop is
started.

I think there is space in the API for having 'setters' for each of the
fields too. The idea behind this is to allow the `struct webview*` to be
treated as an opaque pointer for embedding and FFI.