### PR TITLE
Fix MacOS example C build

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Build it:
 # Linux
 $ cc main.c -DWEBVIEW_GTK=1 `pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.0` -o webview-example
 # MacOS
-$ cc main.c -DWEBVIEW_COCOA=1 -x objective-c -framework Cocoa -framework WebKit -o webview-example
+$ cc main.c -DWEBVIEW_COCOA=1 -x objective-c -ObjC -framework Cocoa -framework WebKit -o webview-example
 # Windows (mingw)
 $ cc main.c -DWEBVIEW_WINAPI=1 -lole32 -lcomctl32 -loleaut32 -luuid -mwindows -o webview-example.exe
 ```


### PR DESCRIPTION
Running the example `cc` command didn't work for me without the `-ObjC` option.