### PR TITLE
Wire dialog "args" to filename and fix dialog "title" support on Windows

### DIFF
--- a/webview.go
+++ b/webview.go
@@ -208,8 +208,9 @@ type WebView interface {
 	// details.
 	InjectCSS(css string)
 	// Dialog() opens a system dialog of the given type and title. String
-	// argument can be provided for certain dialogs, such as alert boxes. For
-	// alert boxes argument is a message inside the dialog box.
+	// argument can be provided for certain dialogs, such as alert boxes or save dialogs.
+	// For alert boxes argument is a message inside the dialog box. For save dialogs
+	// argument is the pre-populated, default filename.
 	Dialog(dlgType DialogType, flags int, title string, arg string) string
 	// Terminate() breaks the main UI loop. This method must be called from the main thread
 	// only. See Dispatch() for more details.

--- a/webview.h
+++ b/webview.h
@@ -1540,9 +1540,20 @@ WEBVIEW_API void webview_dialog(struct webview *w,
       if (strncmp(arg, "", 1) != 0) {
         WCHAR *warg = webview_to_utf16(arg);
         if (dlg->lpVtbl->SetFileName(dlg, warg) != S_OK) {
+          GlobalFree(warg);
           goto error_dlg;
         }
+        GlobalFree(warg);
       }
+    }
+
+    if (strncmp(title, "", 1) != 0) {
+      WCHAR *wtitle = webview_to_utf16(title);
+      if (dlg->lpVtbl->SetTitle(dlg, wtitle) != S_OK) {
+        GlobalFree(wtitle);
+        goto error_dlg;
+      }
+      GlobalFree(wtitle);
     }
     if (dlg->lpVtbl->GetOptions(dlg, &opts) != S_OK) {
       goto error_dlg;

--- a/webview.h
+++ b/webview.h
@@ -396,6 +396,10 @@ WEBVIEW_API void webview_dialog(struct webview *w,
     gtk_file_chooser_set_show_hidden(GTK_FILE_CHOOSER(dlg), TRUE);
     gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(dlg), TRUE);
     gtk_file_chooser_set_create_folders(GTK_FILE_CHOOSER(dlg), TRUE);
+    if (dlgtype == WEBVIEW_DIALOG_TYPE_SAVE &&
+        g_strcmp0(arg, "") != 0) {
+      gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(dlg), arg);
+    }
     gint response = gtk_dialog_run(GTK_DIALOG(dlg));
     if (response == GTK_RESPONSE_ACCEPT) {
       gchar *filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dlg));
@@ -1532,6 +1536,13 @@ WEBVIEW_API void webview_dialog(struct webview *w,
                   FOS_ALLNONSTORAGEITEMS | FOS_NOVALIDATE | FOS_SHAREAWARE |
                   FOS_NOTESTFILECREATE | FOS_NODEREFERENCELINKS |
                   FOS_FORCESHOWHIDDEN | FOS_DEFAULTNOMINIMODE;
+
+      if (strncmp(arg, "", 1) != 0) {
+        WCHAR *warg = webview_to_utf16(arg);
+        if (dlg->lpVtbl->SetFileName(dlg, warg) != S_OK) {
+          goto error_dlg;
+        }
+      }
     }
     if (dlg->lpVtbl->GetOptions(dlg, &opts) != S_OK) {
       goto error_dlg;
@@ -1818,6 +1829,9 @@ WEBVIEW_API void webview_dialog(struct webview *w,
       panel = openPanel;
     } else {
       panel = [NSSavePanel savePanel];
+      if (strncmp(arg, "", 1) != 0) {
+        [panel setNameFieldStringValue:[NSString stringWithUTF8String:arg]];
+      }
     }
     [panel setCanCreateDirectories:YES];
     [panel setShowsHiddenFiles:YES];


### PR DESCRIPTION
- Add ability to set file name for save dialog
- Fixes the ability to set the title for open or save dialog on Windows.

## Given
```go
case data == "save":
	log.Println("save", w.Dialog(webview.DialogTypeSave, 0, "Save file", "MyFile"))
```

## Before changes (windows)
![image](https://user-images.githubusercontent.com/3238999/42066449-642d0654-7af5-11e8-8770-c38e61aef798.png)

## After changes (windows)
![image](https://user-images.githubusercontent.com/3238999/42066525-cb3981e2-7af5-11e8-802d-9fd9aa067e53.png)

** Note the title and filename

