### PR TITLE
Fix uninitialized variable

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -1575,7 +1575,7 @@ WEBVIEW_API void webview_dialog(struct webview *w,
     IShellItem *res = NULL;
     WCHAR *ws = NULL;
     char *s = NULL;
-    FILEOPENDIALOGOPTIONS opts, add_opts;
+    FILEOPENDIALOGOPTIONS opts = 0, add_opts = 0;
     if (dlgtype == WEBVIEW_DIALOG_TYPE_OPEN) {
       if (CoCreateInstance(
               iid_unref(&CLSID_FileOpenDialog), NULL, CLSCTX_INPROC_SERVER,


### PR DESCRIPTION
Fixes uninitialized FILEOPENDIALOGOPTIONS variable used to display
dialogs on Windows.
This sometimes caused problem in debug builds vs release builds.
Sometimes the dialog would not show and sometimes it would (There was
probably some garbage initialized to these variables in debug builds
and they were correctly initialized to 0 in release builds).

This also fixes Boscop/web-view#29.
