### PR TITLE
Move to JavaScriptCore Glib API over DOM API

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -250,14 +250,19 @@ static void external_message_received_cb(WebKitUserContentManager *m,
   if (w->external_invoke_cb == NULL) {
     return;
   }
+#if WEBKIT_MAJOR_VERSION >= 2 && WEBKIT_MINOR_VERSION >= 22
+  JSCValue *value = webkit_javascript_result_get_js_value(r);
+  char *s = jsc_value_to_string(value);
+#else
   JSGlobalContextRef context = webkit_javascript_result_get_global_context(r);
   JSValueRef value = webkit_javascript_result_get_value(r);
   JSStringRef js = JSValueToStringCopy(context, value, NULL);
   size_t n = JSStringGetMaximumUTF8CStringSize(js);
   char *s = g_new(char, n);
   JSStringGetUTF8CString(js, s, n);
-  w->external_invoke_cb(w, s);
   JSStringRelease(js);
+#endif
+  w->external_invoke_cb(w, s);
   g_free(s);
 }
 


### PR DESCRIPTION
In WebkitGTK 2.22 webkit_javascript_result_get_value() was depricated in
favor of webkit_javascript_result_get_js_value().  This change will use
the new JSC API when WebkitGTK 2.22 is present.

Fixes #192