### PR TITLE
Do NOT handle uninitialized messages

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -1326,9 +1326,9 @@ WEBVIEW_API int webview_init(struct webview *w) {
 WEBVIEW_API int webview_loop(struct webview *w, int blocking) {
   MSG msg;
   if (blocking) {
-    GetMessage(&msg, 0, 0, 0);
+    if (GetMessage(&msg, 0, 0, 0)<0) return 0;
   } else {
-    PeekMessage(&msg, 0, 0, 0, PM_REMOVE);
+    if (!PeekMessage(&msg, 0, 0, 0, PM_REMOVE)) return 0;
   }
   switch (msg.message) {
   case WM_QUIT:


### PR DESCRIPTION
Both, [GetMessage ](https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-getmessage) and [PeekMessage](https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-peekmessagew), can end up not filling out the msg struct.
In those cases we have garbage in the struct and must not handle anything.

#220 Fix