### PR TITLE
Fixed bug in Windows 7 where window does not close 

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -1653,7 +1653,12 @@ WEBVIEW_API void webview_dialog(struct webview *w,
 }
 
 WEBVIEW_API void webview_terminate(struct webview *w) { PostQuitMessage(0); }
-WEBVIEW_API void webview_exit(struct webview *w) { OleUninitialize(); }
+
+WEBVIEW_API void webview_exit(struct webview *w) {
+  DestroyWindow(w->priv.hwnd);
+  OleUninitialize();
+}
+
 WEBVIEW_API void webview_print_log(const char *s) { OutputDebugString(s); }
 
 #endif /* WEBVIEW_WINAPI */


### PR DESCRIPTION
On Windows 7,  if you call WebView.Exit() without immediately terminating the entire Go process, the Webview will not be destroyed, and will appear to be frozen. This PR solves that problem, although you may wish to test it on later versions of Windows.