### PR TITLE
macos: Explicitly set window alpha value on color change

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -2143,6 +2143,7 @@ WEBVIEW_API void webview_set_color(struct webview *w, uint8_t r, uint8_t g,
                               get_nsstring("NSAppearanceNameVibrantLight")));
   }
   objc_msgSend(w->priv.window, sel_registerName("setOpaque:"), 0);
+  objc_msgSend(w->priv.window, sel_registerName("setAlphaValue:"), (float)a / 255.0);
   objc_msgSend(w->priv.window,
                sel_registerName("setTitlebarAppearsTransparent:"), 1);
 }


### PR DESCRIPTION
With this change I'm able to create a window with varying opacity on macOS, as verified by using RGBA syntax in the window-go sample app.

However, my intent was to allow RGBA syntax to work directly from the embedded HTML (ie, body.style = "RGBA(128,128,128,128); opacity = 0.5;") but that still doesn't work.

As such, I'm not sure if this is the correct way to solve the issue or if I'm missing something.