### PR TITLE
Create edit menu with Copy/Cut/Paste/Select All support

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -2088,6 +2088,15 @@ WEBVIEW_API int webview_init(struct webview *w) {
   objc_msgSend(editMenuItem, sel_registerName("setSubmenu:"), editMenu);
   objc_msgSend(menubar, sel_registerName("addItem:"), editMenuItem);
 
+  item = create_menu_item(get_nsstring("Undo"), "undo:", "z");
+  objc_msgSend(editMenu, sel_registerName("addItem:"), item);
+
+  item = create_menu_item(get_nsstring("Redo"), "redo:", "y");
+  objc_msgSend(editMenu, sel_registerName("addItem:"), item);
+
+  item = objc_msgSend((id)objc_getClass("NSMenuItem"), sel_registerName("separatorItem"));
+  objc_msgSend(editMenu, sel_registerName("addItem:"), item);
+
   item = create_menu_item(get_nsstring("Cut"), "cut:", "x");
   objc_msgSend(editMenu, sel_registerName("addItem:"), item);
 

--- a/webview.h
+++ b/webview.h
@@ -2014,6 +2014,10 @@ WEBVIEW_API int webview_init(struct webview *w) {
                             sel_registerName("sharedApplication")),
                sel_registerName("activateIgnoringOtherApps:"), 1);
 
+  /***
+   Create menubar
+   ***/
+
   id menubar =
       objc_msgSend((id)objc_getClass("NSMenu"), sel_registerName("alloc"));
   objc_msgSend(menubar, sel_registerName("initWithTitle:"), get_nsstring(""));
@@ -2022,6 +2026,10 @@ WEBVIEW_API int webview_init(struct webview *w) {
   id appName = objc_msgSend(objc_msgSend((id)objc_getClass("NSProcessInfo"),
                                          sel_registerName("processInfo")),
                             sel_registerName("processName"));
+
+  /***
+   Main application menu
+   ***/
 
   id appMenuItem =
       objc_msgSend((id)objc_getClass("NSMenuItem"), sel_registerName("alloc"));
@@ -2061,6 +2069,40 @@ WEBVIEW_API int webview_init(struct webview *w) {
                        sel_registerName("stringByAppendingString:"), appName);
   item = create_menu_item(title, "terminate:", "q");
   objc_msgSend(appMenu, sel_registerName("addItem:"), item);
+
+  id editMenuItem =
+      objc_msgSend((id)objc_getClass("NSMenuItem"), sel_registerName("alloc"));
+  objc_msgSend(editMenuItem,
+               sel_registerName("initWithTitle:action:keyEquivalent:"), get_nsstring("Edit"),
+               NULL, get_nsstring(""));
+
+  /***
+   Edit menu
+   ***/
+
+  id editMenu =
+      objc_msgSend((id)objc_getClass("NSMenu"), sel_registerName("alloc"));
+  objc_msgSend(editMenu, sel_registerName("initWithTitle:"), get_nsstring("Edit"));
+  objc_msgSend(editMenu, sel_registerName("autorelease"));
+
+  objc_msgSend(editMenuItem, sel_registerName("setSubmenu:"), editMenu);
+  objc_msgSend(menubar, sel_registerName("addItem:"), editMenuItem);
+
+  item = create_menu_item(get_nsstring("Cut"), "cut:", "x");
+  objc_msgSend(editMenu, sel_registerName("addItem:"), item);
+
+  item = create_menu_item(get_nsstring("Copy"), "copy:", "c");
+  objc_msgSend(editMenu, sel_registerName("addItem:"), item);
+
+  item = create_menu_item(get_nsstring("Paste"), "paste:", "v");
+  objc_msgSend(editMenu, sel_registerName("addItem:"), item);
+
+  item = create_menu_item(get_nsstring("Select All"), "selectAll:", "a");
+  objc_msgSend(editMenu, sel_registerName("addItem:"), item);
+
+  /***
+   Finalize menubar
+   ***/
 
   objc_msgSend(objc_msgSend((id)objc_getClass("NSApplication"),
                             sel_registerName("sharedApplication")),


### PR DESCRIPTION
Hi,

This adds support for the following actions on macOS:

* Cut
* Copy
* Paste
* Select All

It also adds it in an "Edit" menubar to follow the standards set by other macOS applications.

Here's a screenshot of it in an app I'm writing:

<img width="314" alt="screen shot 2019-02-14 at 11 26 13 am" src="https://user-images.githubusercontent.com/1558388/52801222-682d7200-304b-11e9-9061-2ccae390c5b0.png">


---

https://github.com/zserge/webview/issues/99