### PR TITLE
Splitted Bind() into two functions to be able to inject js code by <script>

### DIFF
--- a/webview.go
+++ b/webview.go
@@ -569,6 +569,11 @@ func (w *webview) BindQuery(name string, v interface{}) (sync func(), js string,
 	}
 	m.Unlock()
 
+	// add a first sync to the code
+	if syncJs, err := b.Sync(); err == nil {
+		js += "\r\n" + syncJs
+	}
+
 	return sync, js, nil
 }
 
@@ -579,6 +584,7 @@ func (w *webview) Bind(name string, v interface{}) (sync func(), err error) {
 		return nil, err
 	}
 	w.Eval(js)
-	sync()
+	// don't need a first sync because it is appended already
+	// sync()
 	return sync, err
 }


### PR DESCRIPTION
A new BindQuery() function does in fact the same as Bind() but without dispatching an eval() of the newly generated JavaScript.

This allows for an interesting and clean way of querying the injection of service controllers from the view itself via <script src=".."> by providing an API endpoint within the applications webserver. Its an enabler for a clean and comprehensive go/webview gui application template I made.

If navigation worked in webview, this could be also used to inject only necessary controllers within the views context.