### PR TITLE
(Go) Don't delete binding after it is called.

### DIFF
--- a/webview.go
+++ b/webview.go
@@ -229,7 +229,6 @@ func _webviewDispatchGoCallback(index unsafe.Pointer) {
 func _webviewBindingGoCallback(w C.webview_t, id *C.char, req *C.char, index uintptr) {
 	m.Lock()
 	f := bindings[uintptr(index)]
-	delete(bindings, uintptr(index))
 	m.Unlock()
 	jsString := func(v interface{}) string { b, _ := json.Marshal(v); return string(b) }
 	status, result := 0, ""


### PR DESCRIPTION
This fixes #323.

For some reason (I don't know why), the binding is deleted after it is invoked. So it works on the first time (and then it is deleted) and then fails on the second time. In `_webviewBindingGoCallback`, `f` becomes nil.

Also, just wondering, is it actually necessary to mutex-lock `bindings`? After this PR, `bindings` is modified by `Bind` but it is read-only by `_webviewBindingGoCallback`. Since there is only one writer, maybe the mutex is unecessary?


