### PR TITLE
Don't call window._rpc if does not exist.

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -1136,11 +1136,11 @@ public:
   void resolve(const std::string seq, int status, const std::string result) {
     dispatch([=]() {
       if (status == 0) {
-        eval("window._rpc[" + seq + "].resolve(" + result + "); window._rpc[" +
-             seq + "] = undefined");
+        eval("if (window._rpc) { window._rpc[" + seq + "].resolve(" + result + "); window._rpc[" +
+             seq + "] = undefined }");
       } else {
-        eval("window._rpc[" + seq + "].reject(" + result + "); window._rpc[" +
-             seq + "] = undefined");
+        eval("if (window._rpc) { window._rpc[" + seq + "].reject(" + result + "); window._rpc[" +
+             seq + "] = undefined }");
       }
     });
   }


### PR DESCRIPTION
For unknown reasons (maybe when repeatedly destroying and
creating new WebViews?), sometimes `window._rpc` does not exist.
This avoids a 'undefined is not an object' spurious error message.