### PR TITLE
Add title bar icon for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ example.app
 
 Here, `Info.plist` is a [property list file](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/AboutInformationPropertyListFiles.html) and `*.icns` is a special icon format. You may convert PNG to icns [online](https://iconverticons.com/online/).
 
-On Windows you probably would like to have a custom icon for your executable. It can be done by providing a resource file, compiling it and linking with it. Typically, `windres` utility is used to compile resources. Also, on Windows, `webview.dll` and `WebView2Loader.dll` must be placed into the same directory with your app executable.
+On Windows you probably would like to have a custom icon for your executable. It can be done by providing a resource file, compiling it and linking with it. Typically, `windres` utility is used to compile resources. To show a icon in the application title bar, just place a file named *icon.ico* next to the executable file.
+Also, on Windows, `webview.dll` and `WebView2Loader.dll` must be placed into the same directory with your app executable.
 
 Also, if you want to cross-compile your webview app - use [xgo](https://github.com/karalabe/xgo).
 

--- a/webview.h
+++ b/webview.h
@@ -937,11 +937,19 @@ class win32_edge_engine {
 public:
   win32_edge_engine(bool debug, void *window) {
     if (window == nullptr) {
+      HICON icon = (HICON) LoadImage(
+        NULL, "icon.ico", IMAGE_ICON,
+        GetSystemMetrics(SM_CXSMICON), 
+        GetSystemMetrics(SM_CYSMICON), 
+        LR_LOADFROMFILE);
+
       WNDCLASSEX wc;
       ZeroMemory(&wc, sizeof(WNDCLASSEX));
       wc.cbSize = sizeof(WNDCLASSEX);
       wc.hInstance = GetModuleHandle(nullptr);
       wc.lpszClassName = "webview";
+      wc.hIcon = icon;
+      wc.hIconSm = icon;
       wc.lpfnWndProc =
           (WNDPROC)(+[](HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) -> int {
             auto w = (win32_edge_engine *)GetWindowLongPtr(hwnd, GWLP_USERDATA);


### PR DESCRIPTION
On windows, even if the executable has a ressource file icon, it is only shown as the executable icon in the file explorer. This commit loads an *icon.ico* file, put next to the executable, as the icon for the application title bar.