### PR TITLE
Initialize point vars for windows

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -1061,8 +1061,8 @@ private:
   virtual void on_message(const std::string msg) = 0;
 
   HWND m_window;
-  POINT m_minsz;
-  POINT m_maxsz;
+  POINT m_minsz = POINT { 0, 0 };
+  POINT m_maxsz = POINT { 0, 0 };
   DWORD m_main_thread = GetCurrentThreadId();
   std::unique_ptr<webview::browser> m_browser =
       std::make_unique<webview::edge_chromium>();


### PR DESCRIPTION
In some occasions, if compiled in Release Mode, the variables m_minsz and m_maxsz were pointing to random memory. This caused weird effects on windows. From application crash to operating system crash.