### PR TITLE
Windows: Hide window until run

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -982,7 +982,7 @@ public:
       m_window = *(static_cast<HWND *>(window));
     }
 
-    ShowWindow(m_window, SW_SHOW);
+    ShowWindow(m_window, SW_HIDE);
     UpdateWindow(m_window);
     SetFocus(m_window);
 
@@ -998,6 +998,8 @@ public:
   }
 
   void run() {
+    ShowWindow(m_window, SW_SHOW);
+    
     MSG msg;
     BOOL res;
     while ((res = GetMessage(&msg, nullptr, 0, 0)) != -1) {


### PR DESCRIPTION
Because the window is shown as soon as the webview gets created, it is possible, that the end users see a 'flickering' window. For example, if the developer sets the size of the window, first a window is shown with default sizes and no content, then it gets resized (flickering).

This commit creates a 'hidden' window on initialization and it gets shown on calling the run method. In between of the initialization and running the webview the change of configuration parameters, through calling methods like set_title and set_size, will only affect the hidden window and it will not occur as 'flickering' to the user.